### PR TITLE
dashboard v1.4 enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- [utils.dashboard] Reader struct to ease passing `readers` to dashboard YAML
+- [utils.dashboard] Link struct to ease passing `links` to dashboard YAML
+- [builder] `add_dashboard()` param: `readers` to automatically add and offer Kiwix readers in dashboard (1.4+)
+- [builder] `add_dashboard()` param: `links` to add arbitrary links to dashboard (1.4+)
+
+## Changed
+
+- [builder] `resolved_variable()` can now be used without a Package
+
 ## [1.12.2] - 2024-03-14
 
 ### Fixed

--- a/src/offspot_config/utils/dashboard.py
+++ b/src/offspot_config/utils/dashboard.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pathlib
+import urllib.parse
+from typing import NamedTuple, TypeVar
+
+from offspot_config.utils.download import get_online_rsc_size
+
+R = TypeVar("R", bound="Reader")
+
+
+class Reader(NamedTuple):
+    """Downloadable Kiwix Reader software information
+
+    Used to build offspot dashboard so it can offer links to download said softwares
+    allowing users to use ZIMs locally"""
+
+    platform: str
+    download_url: str
+    filename: str
+    size: int
+
+    def to_dict(self) -> dict[str, str | int]:
+        return {field: getattr(self, field) for field in self._fields}
+
+    @property
+    def order(self) -> int:
+        """sort-usable order based on reader's platform popularity"""
+        return {"windows": 0, "android": 1, "macos": 2, "linux": 3}.get(
+            self.platform, 4
+        )
+
+    @classmethod
+    def using(cls: type[R], platform: str, download_url: str) -> R:
+        """Reader from a platform name and download URL"""
+        return cls(
+            platform=platform,
+            download_url=download_url,
+            size=get_online_rsc_size(download_url),
+            filename=cls.filename_from_url(download_url),
+        )
+
+    @staticmethod
+    def filename_from_url(url: str) -> str:
+        """suggested filename from reader download URL"""
+        return pathlib.Path(urllib.parse.urlparse(url).path).name
+
+    @staticmethod
+    def sort(reader: Reader) -> int:
+        """sorted key function to sort by reader's order"""
+        return reader.order
+
+
+class Link(NamedTuple):
+    """Link to an arbitrary resource
+
+    used to build offspot dashboard so additional (not content) resources can be
+    linked to
+
+    icon is tied to implementation and currently should be either unset (empty)
+    or the name of a FontAwesome 6 icon
+    https://fontawesome.com/v6/search?o=r&m=free"""
+
+    label: str
+    url: str
+    icon: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {field: getattr(self, field) for field in self._fields}

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,0 +1,50 @@
+import pytest  # pyright: ignore [reportMissingImports]
+
+from offspot_config.utils.dashboard import Link
+
+
+def test_link_is_tuple():
+    label = "Metrics"
+    url = "://metrics.kiwix.hotspot"
+    icon = "lock"
+    assert Link(label, url) == (label, url, "")
+    assert Link(label, url, icon) == (label, url, icon)
+    assert Link(url=url, icon=icon, label=label) == (label, url, icon)
+    assert isinstance(Link(label, url, icon), Link)
+    assert isinstance(Link(label, url, icon), tuple)
+    tuple_ = (label, url, icon)
+    casted = Link._make(tuple_)
+    assert isinstance(casted, Link)
+
+
+@pytest.mark.parametrize(
+    "label, url, icon, expected_dict",
+    [
+        (
+            "Metrics",
+            "://metrics.kiwix.hotspot",
+            "",
+            {
+                "label": "Metrics",
+                "url": "://metrics.kiwix.hotspot",
+                "icon": "",
+            },
+        ),
+        (
+            "Admin",
+            "://admin.kiwix.hotspot",
+            "lock",
+            {
+                "label": "Admin",
+                "url": "://admin.kiwix.hotspot",
+                "icon": "lock",
+            },
+        ),
+    ],
+)
+def test_to_dict(label, url, icon, expected_dict):
+    if icon:
+        link = Link(label, url, icon)
+    else:
+        link = Link(label=label, url=url)
+    assert link.to_dict() == expected_dict

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,0 +1,165 @@
+import pytest  # pyright: ignore [reportMissingImports]
+
+from offspot_config.utils.dashboard import Reader
+
+REALISTIC_VALUES = [
+    (
+        "linux",
+        "https://download.kiwix.org/release/kiwix-desktop/kiwix-desktop_x86_64_2.3.1-4.appimage",
+        "kiwix-desktop_x86_64_2.3.1-4.appimage",
+        146629824,
+    ),
+    (
+        "android",
+        "https://download.kiwix.org/release/kiwix-android/kiwix-3.9.1.apk",
+        "kiwix-3.9.1.apk",
+        79629012,
+    ),
+    (
+        "windows",
+        "https://download.kiwix.org/release/kiwix-desktop/kiwix-desktop_windows_x64_2.3.1-2.zip",
+        "kiwix-desktop_windows_x64_2.3.1-2.zip",
+        126628211,
+    ),
+    (
+        "macos",
+        "https://download.kiwix.org/release/kiwix-desktop-macos/kiwix-desktop-macos_3.1.0.dmg",
+        "kiwix-desktop-macos_3.1.0.dmg",
+        16051402,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "url, expected_filename",
+    [
+        (
+            "https://download.kiwix.org/release/kiwix-desktop/kiwix-desktop_windows_x64_2.3.1-2.zip",
+            "kiwix-desktop_windows_x64_2.3.1-2.zip",
+        ),
+        (
+            "https://download.kiwix.org/release/kiwix-android/kiwix-3.9.1.apk",
+            "kiwix-3.9.1.apk",
+        ),
+        (
+            "https://download.kiwix.org/release/kiwix-desktop-macos/kiwix-desktop-macos_3.1.0.dmg",
+            "kiwix-desktop-macos_3.1.0.dmg",
+        ),
+        (
+            "https://download.kiwix.org/release/kiwix-desktop/kiwix-desktop_x86_64_2.3.1-4.appimage",
+            "kiwix-desktop_x86_64_2.3.1-4.appimage",
+        ),
+        ("https://www.freecodecamp.org/news/css-unit-guide/", "css-unit-guide"),
+    ],
+)
+def test_filename_from_url(url: str, expected_filename: str):
+    assert Reader.filename_from_url(url) == expected_filename
+
+
+def test_reader_is_tuple():
+    platform = "windows"
+    url = "http://some.tld/file"
+    filename = "one"
+    size = 4
+    assert Reader(platform, url, filename, size) == (platform, url, filename, size)
+    assert Reader(
+        download_url=url, size=size, platform=platform, filename=filename
+    ) == (platform, url, filename, size)
+    assert isinstance(Reader(platform, url, filename, size), Reader)
+    assert isinstance(Reader(platform, url, filename, size), tuple)
+    tuple_ = (platform, url, filename, size)
+    casted = Reader._make(tuple_)
+    assert isinstance(casted, Reader)
+
+
+@pytest.mark.parametrize("platform, download_url, filename, size", REALISTIC_VALUES)
+def test_reader_using(platform: str, download_url: str, filename: str, size: int):
+    assert Reader.using(platform, download_url) == Reader(
+        platform, download_url, filename, size
+    )
+    assert Reader.using(platform=platform, download_url=download_url) == Reader(
+        platform, download_url, filename, size
+    )
+
+
+@pytest.mark.parametrize("platform, download_url, filename, size", REALISTIC_VALUES)
+def test_invalid_data(platform: str, download_url: str, filename: str, size: int):
+    with pytest.raises(TypeError):
+        Reader(platform, download_url, filename)  # pyright: ignore [reportCallIssue]
+    with pytest.raises(TypeError):
+        Reader(
+            platform,
+            download_url,
+            filename,
+            size,
+            32,  # pyright: ignore [reportCallIssue]
+        )
+    with pytest.raises(TypeError):
+        Reader(platform=platform)  # pyright: ignore [reportCallIssue]
+    with pytest.raises(TypeError):
+        Reader(download_url=download_url)  # pyright: ignore [reportCallIssue]
+    with pytest.raises(TypeError):
+        Reader.using(
+            platform, download_url, filename, size  # pyright: ignore [reportCallIssue]
+        )
+
+
+def test_sort_order():
+    readers = [Reader(*values) for values in REALISTIC_VALUES]
+    sorted_readers = sorted(readers, key=Reader.sort)
+    assert readers != sorted_readers
+    assert [r.platform for r in sorted_readers] == [
+        "windows",
+        "android",
+        "macos",
+        "linux",
+    ]
+
+
+@pytest.mark.parametrize(
+    "platform, download_url, filename, size, expected_dict",
+    [
+        (
+            "android",
+            "https://download.kiwix.org/release/kiwix-android/kiwix-3.9.1.apk",
+            "kiwix-3.9.1.apk",
+            79629012,
+            {
+                "platform": "android",
+                "download_url": "https://download.kiwix.org/release/kiwix-android/kiwix-3.9.1.apk",
+                "filename": "kiwix-3.9.1.apk",
+                "size": 79629012,
+            },
+        ),
+        (
+            "windows",
+            "https://download.kiwix.org/release/kiwix-desktop/kiwix-desktop_windows_x64_2.3.1-2.zip",
+            "kiwix-desktop_windows_x64_2.3.1-2.zip",
+            126628211,
+            {
+                "platform": "windows",
+                "download_url": "https://download.kiwix.org/release/kiwix-desktop/kiwix-desktop_windows_x64_2.3.1-2.zip",
+                "filename": "kiwix-desktop_windows_x64_2.3.1-2.zip",
+                "size": 126628211,
+            },
+        ),
+        (
+            "macos",
+            "https://download.kiwix.org/release/kiwix-desktop-macos/kiwix-desktop-macos_3.1.0.dmg",
+            None,
+            None,
+            {
+                "platform": "macos",
+                "download_url": "https://download.kiwix.org/release/kiwix-desktop-macos/kiwix-desktop-macos_3.1.0.dmg",
+                "filename": "kiwix-desktop-macos_3.1.0.dmg",
+                "size": 16051402,
+            },
+        ),
+    ],
+)
+def test_to_dict(platform, download_url, filename, size, expected_dict):
+    if filename and size:
+        reader = Reader(platform, download_url, filename, size)
+    else:
+        reader = Reader.using(platform=platform, download_url=download_url)
+    assert reader.to_dict() == expected_dict


### PR DESCRIPTION
Added support for `links` and `readers` in dashboard (supported in dashboard 1.4+)

Links allow arbitrary links to be added to the dashboard (in footer) Readers are presented and downloadable from the downloads tab