### PR TITLE
Add packages for Af&Rica Android application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [catalog] Added Af&Rica files packages in FR, EN, AR.
+
 ### Changed
 
 - [catalog] Update name and description for file-manager.offspot.kiwix.org (now File Manager)

--- a/src/offspot_config/catalog.json
+++ b/src/offspot_config/catalog.json
@@ -409,10 +409,10 @@
         ],
         "icon_url": "https://drive.offspot.it/af-rica/icon.png",
         "download_url": "https://drive.offspot.it/af-rica/af_and_rica_ar_1.0.0.zip",
-        "download_size": 42956189,
+        "download_size": 46509014,
         "download_checksum": {
             "algo": "md5",
-            "value": "007d72d211f3d9241de4ea3fc26d2f94"
+            "value": "ed2994a67844c68fd4adfc1dab8f6cdd"
         },
         "via": "zip"
     },
@@ -430,10 +430,10 @@
         ],
         "icon_url": "https://drive.offspot.it/af-rica/icon.png",
         "download_url": "https://drive.offspot.it/af-rica/af_and_rica_en_1.0.0.zip",
-        "download_size": 42956094,
+        "download_size": 46508913,
         "download_checksum": {
             "algo": "md5",
-            "value": "7d083c24f06263ca34ba5ca223dadb75"
+            "value": "4a7098275be7eb0ce94b387a71bdf8eb"
         },
         "via": "zip"
     },
@@ -451,10 +451,10 @@
         ],
         "icon_url": "https://drive.offspot.it/af-rica/icon.png",
         "download_url": "https://drive.offspot.it/af-rica/af_and_rica_fr_1.0.0.zip",
-        "download_size": 42956143,
+        "download_size": 46508976,
         "download_checksum": {
             "algo": "md5",
-            "value": "11161481259c3654de047c63ca9f7fab"
+            "value": "14ab4def1fcd518dd12f529fd41bb354"
         },
         "via": "zip"
     }

--- a/src/offspot_config/catalog.json
+++ b/src/offspot_config/catalog.json
@@ -394,5 +394,68 @@
             "value": "b1a1e31076651b212b6b08f7cd897e07"
         },
         "via": "zip"
+    },
+    {
+        "ident": "com.af-et-rica.dcx.ar.offspot.kiwix.org",
+        "domain": "com.af-et-rica.dcx.ar",
+        "kind": "files",
+        "title": "Af&Rica",
+        "description": "العب واكتشف الثقافات الإفريقية مع المغامرين أف و ريكا",
+        "languages": [
+            "ara"
+        ],
+        "tags": [
+            "android"
+        ],
+        "icon_url": "https://drive.offspot.it/af-rica/icon.png",
+        "download_url": "https://drive.offspot.it/af-rica/af_and_rica_ar_1.0.0.zip",
+        "download_size": 42956189,
+        "download_checksum": {
+            "algo": "md5",
+            "value": "007d72d211f3d9241de4ea3fc26d2f94"
+        },
+        "via": "zip"
+    },
+    {
+        "ident": "com.af-et-rica.dcx.en.offspot.kiwix.org",
+        "domain": "com.af-et-rica.dcx.en",
+        "kind": "files",
+        "title": "Af&Rica",
+        "description": "Play and discover African cultures with the two adventurers Af and Rica.",
+        "languages": [
+            "eng"
+        ],
+        "tags": [
+            "android"
+        ],
+        "icon_url": "https://drive.offspot.it/af-rica/icon.png",
+        "download_url": "https://drive.offspot.it/af-rica/af_and_rica_en_1.0.0.zip",
+        "download_size": 42956094,
+        "download_checksum": {
+            "algo": "md5",
+            "value": "7d083c24f06263ca34ba5ca223dadb75"
+        },
+        "via": "zip"
+    },
+    {
+        "ident": "com.af-et-rica.dcx.fr.offspot.kiwix.org",
+        "domain": "com.af-et-rica.dcx.fr",
+        "kind": "files",
+        "title": "Af&Rica",
+        "description": "Jouez et découvrez les cultures Africaines avec les deux aventuriers Af & Rica.",
+        "languages": [
+            "fra"
+        ],
+        "tags": [
+            "android"
+        ],
+        "icon_url": "https://drive.offspot.it/af-rica/icon.png",
+        "download_url": "https://drive.offspot.it/af-rica/af_and_rica_fr_1.0.0.zip",
+        "download_size": 42956143,
+        "download_checksum": {
+            "algo": "md5",
+            "value": "11161481259c3654de047c63ca9f7fab"
+        },
+        "via": "zip"
     }
 ]


### PR DESCRIPTION
Fix https://github.com/offspot/package-requests/issues/44

Adding the three languages of Af&Rica application.

Zip files created manually with custom homepage "f-droid like".

Nota: while Android package name is `com.AfRica.DCX`, I've chosen a slightly better `ident` with less risks of collision (pretty sure `africa.com` is not owned by Orange).