### PR TITLE
Add WiFi profiles and Admin UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Applied configuration (from offspot.yaml) now recorded to /etc/offspot/latest.yaml
+- [runtime] `fromfile` Records applied configuration (from offspot.yaml) to /etc/offspot/latest.yaml
+- [runtime] `ap` now supports `profile` (`perf` or `coverage`)
 
 ## [2.7.1] - 2025-10-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [runtime] `fromfile` Records applied configuration (from offspot.yaml) to /etc/offspot/latest.yaml
 - [runtime] `ap` now supports `profile` (`perf` or `coverage`)
+- [builder] Admin UI support via `.add_adminui()`
 
 ## [2.7.1] - 2025-10-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Applied configuration (from offspot.yaml) now recorded to /etc/offspot/latest.yaml
+
 ## [2.7.1] - 2025-10-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -206,10 +206,12 @@ Without an *armor*, configuration is appended at end of file, specifying `eth0` 
 
 | Member              | Kind       | Required | Function                                                                                                         |
 |---------------------|----------- |----------|------------------------------------------------------------------------------------------------------------------|
-| `ssid    `          | `string`   | **yes**  | SSID (Network Name)                                                                                              |
+| `ssid`              | `string`   | **yes**  | SSID (Network Name)                                                                                              |
 | `passphrase`        | `string`   | no       | Passphrase/password to connect to the network. Defaults to Open Network                                          |
-| `address`           | `string`   | no       | IP address to set on the wireless interface. Defaults to 192.168.144.1                                             |
-| `channel`           | `integer`  | no       | WiFi channel to use for the network (1-14). Defaults to `11`.                                                    |
+| `profile`           | `string`   | no       | AP Configuration: `perf` (802.11ac@5Ghz – requires brcm43455), `coverage`  (802.11n@2.4Ghz).  Defaults to `perf`.|
+| `address`           | `string`   | no       | IP address to set on the wireless interface. Defaults to 192.168.144.1                                           |
+| `channel_24`        | `integer`  | no       | WiFi channel to use for 2.4Ghz network (1-14). Defaults to `11`.                                                 |
+| `channel_5`         | `integer`  | no       | WiFi channel to use for 5Ghz network (32, 36, 40, 44). Defaults to `36`.                                         |
 | `country`           | `string`   | no       | Country-code to apply frequencies limitations for. Defaults to `FR`                                              |
 | `hide`              | `boolean`  | no       | Hide SSID (Clients must know and enter its name to connect)                                                      |
 | `interface`         | `string`   | no       | Interface to configure AP for. Defaults to `wlan0`                                                               |

--- a/src/offspot_runtime/containers.py
+++ b/src/offspot_runtime/containers.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-""" Validates and writes a docker-compose payload """
+"""Validates and writes a docker-compose payload"""
 
 import argparse
 import logging

--- a/src/offspot_runtime/dnsmasqspoof.py
+++ b/src/offspot_runtime/dnsmasqspoof.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-""" Toggle dnsmasq's spoof mode when internet connection is offline """
+"""Toggle dnsmasq's spoof mode when internet connection is offline"""
 
 import argparse
 import pathlib

--- a/src/offspot_runtime/ethernet.py
+++ b/src/offspot_runtime/ethernet.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-""" Sets machine's ethernet network config (using dhcpcd5) """
+"""Sets machine's ethernet network config (using dhcpcd5)"""
 
 import argparse
 import logging

--- a/src/offspot_runtime/firmware.py
+++ b/src/offspot_runtime/firmware.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-""" Sets machine's WiFi firmware(s) to use """
+"""Sets machine's WiFi firmware(s) to use"""
 
 import argparse
 import logging

--- a/src/offspot_runtime/fromfile.py
+++ b/src/offspot_runtime/fromfile.py
@@ -147,12 +147,14 @@ class Handlers:
             command += ["--debug"]
 
         for key in (
+            "profile",
             "passphrase",
             "address",
             "tld",
             "domain",
             "welcome",
-            "channel",
+            "channel_24",
+            "channel_5",
             "country",
             "interface",
             "dhcp-range",

--- a/src/offspot_runtime/hostname.py
+++ b/src/offspot_runtime/hostname.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-""" Sets machine's hostname (using systemd) """
+"""Sets machine's hostname (using systemd)"""
 
 import argparse
 import logging

--- a/src/offspot_runtime/timezone.py
+++ b/src/offspot_runtime/timezone.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-""" Sets machine's timezone (using systemd) """
+"""Sets machine's timezone (using systemd)"""
 
 import argparse
 import logging

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -16,6 +16,7 @@ from offspot_runtime.checks import (
     is_valid_interface_name,
     is_valid_ipv4,
     is_valid_network,
+    is_valid_profile,
     is_valid_ssid,
     is_valid_timezone,
     is_valid_tld,
@@ -301,6 +302,22 @@ def test_is_valid_ssid(ssid: str, should_pass: bool):
 
 
 @pytest.mark.parametrize(
+    "profile, should_pass",
+    [
+        (1, False),
+        ("kiwix", False),
+        ("coverage", True),
+        ("perf", True),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_is_valid_coverage(profile: str, should_pass: bool):
+    check = is_valid_profile(profile)
+    assert check.passed == should_pass
+
+
+@pytest.mark.parametrize(
     "passphrase, should_pass",
     [
         (1, False),
@@ -524,7 +541,7 @@ def test_is_valid_wifi_country_code(country_code: str, should_pass: bool):
 def test_is_valid_ap_config():
     defaults = {
         "ssid": "",
-        "profile": "coverage",
+        "profile": "",
         "hide": False,
         "passphrase": None,
         "address": "192.168.144.1",
@@ -632,6 +649,11 @@ def test_is_valid_ap_config():
     config["dns"] = ["240.0.0.1"]
     assert not is_valid_ap_config(**config)
     config["dns"] = ["1.1.1.1"]
+    assert is_valid_ap_config(**config)
+
+    config["captured_address"] = "256.192.144.1"
+    assert not is_valid_ap_config(**config)
+    config["captured_address"] = "192.168.144.1"
     assert is_valid_ap_config(**config)
 
     for key in ("other_interfaces", "except_interfaces", "nodhcp_interfaces"):

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -19,7 +19,8 @@ from offspot_runtime.checks import (
     is_valid_ssid,
     is_valid_timezone,
     is_valid_tld,
-    is_valid_wifi_channel,
+    is_valid_24ghz_wifi_channel,
+    is_valid_5ghz_wifi_channel,
     is_valid_wifi_country_code,
     is_valid_wpa2_passphrase,
     port_in_range,
@@ -336,15 +337,137 @@ def test_is_valid_wpa2_passphrase(passphrase: str, should_pass: bool):
         (11, True),
         (12, True),
         (13, True),
-        (14, True),
+        (14, False),
         (15, False),
-        (110, False),
+        (30, False),
+        (31, False),  # bad
+        (32, False),  # bad
+        (34, False),  # U-NII-1
+        (36, False),  # U-NII-1
+        (38, False),  # U-NII-1
+        (40, False),  # U-NII-1
+        (42, False),  # U-NII-1
+        (44, False),  # U-NII-1
+        (46, False),  # U-NII-1
+        (48, False),  # U-NII-1
+        (50, False),  # bad
+        (51, False),  # bad
+        (52, False),  # U-NII-2A
+        (54, False),  # bad
+        (56, False),  # U-NII-2A
+        (60, False),  # U-NII-2A
+        (64, False),  # U-NII-2A
+        (96, False),  # bad
+        (100, False),  # U-NII-2C
+        (102, False),  # bad
+        (104, False),  # U-NII-2C
+        (108, False),  # U-NII-2C
+        (112, False),  # U-NII-2C
+        (116, False),  # U-NII-2C
+        (120, False),  # U-NII-2C
+        (124, False),  # U-NII-2C
+        (128, False),  # U-NII-2C
+        (132, False),  # U-NII-2C
+        (136, False),  # U-NII-2C
+        (140, False),  # U-NII-2C
+        (142, False),  # bad
+        (149, False),  # U-NII-3
+        (151, False),  # bad
+        (153, False),  # U-NII-3
+        (157, False),  # U-NII-3
+        (161, False),  # U-NII-3
+        (165, False),  # U-NII-3
+        (167, False),  # bad
+        (169, False),  # U-NII-4
+        (171, False),  # bad
+        (173, False),  # U-NII-4
+        (175, False),  # bad
+        (177, False),  # U-NII-4
+        (181, False),  # U-NII-4
+        (185, False),  # U-NII-4
     ],
 )
-def test_is_valid_wifi_channel(channel: int, should_pass: bool):
-    check = is_valid_wifi_channel(channel)
+def test_is_valid_24ghz_wifi_channel(channel: int, should_pass: bool):
+    check = is_valid_24ghz_wifi_channel(channel)
     assert check.passed == should_pass
     if check.passed and channel > 11:
+        assert check.help_text
+
+
+@pytest.mark.parametrize(
+    "channel, should_pass",
+    [
+        ("", False),
+        ("6", False),
+        (-1, False),
+        (0, False),
+        (1, False),
+        (2, False),
+        (3, False),
+        (4, False),
+        (5, False),
+        (6, False),
+        (7, False),
+        (8, False),
+        (9, False),
+        (10, False),
+        (11, False),
+        (12, False),
+        (13, False),
+        (14, False),
+        (15, False),
+        (30, False),
+        (31, False),  # bad
+        (32, False),  # U-NII-1
+        (34, False),  # U-NII-1
+        (36, True),  # U-NII-1
+        (38, False),  # U-NII-1
+        (40, True),  # U-NII-1
+        (42, False),  # U-NII-1
+        (44, True),  # U-NII-1
+        (46, False),  # U-NII-1
+        (48, True),  # U-NII-1
+        (50, False),  # bad
+        (51, False),  # bad
+        (52, False),  # U-NII-2A
+        (54, False),  # bad
+        (56, False),  # U-NII-2A
+        (60, False),  # U-NII-2A
+        (64, False),  # U-NII-2A
+        (96, False),  # bad
+        (100, False),  # U-NII-2C
+        (102, False),  # bad
+        (104, False),  # U-NII-2C
+        (108, False),  # U-NII-2C
+        (112, False),  # U-NII-2C
+        (116, False),  # U-NII-2C
+        (120, False),  # U-NII-2C
+        (124, False),  # U-NII-2C
+        (128, False),  # U-NII-2C
+        (132, False),  # U-NII-2C
+        (136, False),  # U-NII-2C
+        (140, False),  # U-NII-2C
+        (142, False),  # bad
+        (149, False),  # U-NII-3
+        (151, False),  # bad
+        (153, False),  # U-NII-3
+        (157, False),  # U-NII-3
+        (161, False),  # U-NII-3
+        (165, False),  # U-NII-3
+        (167, False),  # bad
+        (169, False),  # U-NII-4
+        (171, False),  # bad
+        (173, False),  # U-NII-4
+        (175, False),  # bad
+        (177, False),  # U-NII-4
+        (181, False),  # U-NII-4
+        (185, False),  # U-NII-4
+    ],
+)
+def test_is_valid_5ghz_wifi_channel(channel: int, should_pass: bool):
+    check = is_valid_5ghz_wifi_channel(channel)
+    assert check.passed == should_pass
+    if check.passed and channel != 36:
         assert check.help_text
 
 
@@ -401,6 +524,7 @@ def test_is_valid_wifi_country_code(country_code: str, should_pass: bool):
 def test_is_valid_ap_config():
     defaults = {
         "ssid": "",
+        "profile": "coverage",
         "hide": False,
         "passphrase": None,
         "address": "192.168.144.1",
@@ -409,7 +533,8 @@ def test_is_valid_ap_config():
         "tld": "offspot",
         "domain": "generic",
         "welcome": "goto.generic",
-        "channel": 11,
+        "channel_24": 11,
+        "channel_5": 36,
         "country": "US",
         "interface": "wlan0",
         "dhcp_range": "192.168.144.2,192.168.144.254,255.255.255.0,1h",
@@ -427,6 +552,11 @@ def test_is_valid_ap_config():
     config["ssid"] = "working!"
     assert is_valid_ap_config(**config)
 
+    config["profile"] = "speed"
+    assert not is_valid_ap_config(**config)
+    config["profile"] = "perf"
+    assert is_valid_ap_config(**config)
+
     config["hide"] = "yes"
     assert not is_valid_ap_config(**config)
     config["hide"] = True
@@ -437,9 +567,14 @@ def test_is_valid_ap_config():
     config["passphrase"] = "this is OK"
     assert is_valid_ap_config(**config)
 
-    config["channel"] = 15
+    config["channel_24"] = 15
     assert not is_valid_ap_config(**config)
-    config["channel"] = 6
+    config["channel_24"] = 6
+    assert is_valid_ap_config(**config)
+
+    config["channel_5"] = 32
+    assert not is_valid_ap_config(**config)
+    config["channel_5"] = 40
     assert is_valid_ap_config(**config)
 
     config["country"] = "AAA"

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -145,7 +145,10 @@ def test_invalid_data(
         Reader(download_url=download_url)  # pyright: ignore [reportCallIssue]
     with pytest.raises(TypeError):
         Reader.using(
-            platform, download_url, filename, size  # pyright: ignore [reportCallIssue]
+            platform,
+            download_url,
+            filename,
+            size,  # pyright: ignore [reportCallIssue]
         )
 
 


### PR DESCRIPTION
This introduces the new `profile` param in `ap` which conditionnaly configures WiFi as AC5Ghz or N2.4Ghz.
It also adds support for the `dev` version of the [Admin UI](https://github.com/offspot/adminui) which allows switching between those profiles without editing the offspot YAML manually.

> [!WARNING]
>
> This requires an unreleased version of the base-image ATM

The builder doesn't add the Admin link in Dashboard. This is for the builder user to do.

Fixes https://github.com/offspot/base-image/issues/72
Fixes https://github.com/offspot/offspot-config/issues/2